### PR TITLE
重命名gotify的message参数为content，以保证与其他providers参数保持一致

### DIFF
--- a/onepush/providers/gotify.py
+++ b/onepush/providers/gotify.py
@@ -3,7 +3,7 @@ from ..core import Provider
 class Gotify(Provider):
     name = 'gotify'
     _params = {
-        'required': ['url', 'message', 'token'],
+        'required': ['url', 'content', 'token'],
         'optional': ['title', 'priority']
     }
 
@@ -12,13 +12,13 @@ class Gotify(Provider):
         return self.url
 
     def _prepare_data(self,
-                      message: str,
+                      content: str,
                       title: str = None,
                       priority: int = 0,
                       **kwargs):
         self.data = {
             'title': title,
-            'message': message,
+            'content': content,
             'priority': priority
         }
         return self.data

--- a/onepush/providers/gotify.py
+++ b/onepush/providers/gotify.py
@@ -18,7 +18,7 @@ class Gotify(Provider):
                       **kwargs):
         self.data = {
             'title': title,
-            'content': content,
+            'message': content,
             'priority': priority
         }
         return self.data


### PR DESCRIPTION
重命名gotify的message参数为content，以保证与其他providers参数保持一致 #21 