### PR TITLE
增加Proxy支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,22 @@ from onepush import notify
 notify('bark', key='YOUR_BARK_KEY', title='OnePush', content='Hello World!')
 ```
 
+## Proxy Support
+
+You can use proxy with any notifier by adding the `proxies` parameter:
+
+```python
+# Using HTTP/HTTPS proxy
+proxies = {
+    'http': 'http://127.0.0.1:7890',
+    'https': 'socks5h://127.0.0.1:7890'
+}
+
+notify('bark', 
+       key='YOUR_BARK_KEY', 
+       title='OnePush', 
+       content='Hello World!',
+       proxies=proxies)
+```
+
+The `proxies` parameter accepts the same format as the [requests library](https://requests.readthedocs.io/en/latest/user/advanced/#proxies).

--- a/onepush/core.py
+++ b/onepush/core.py
@@ -26,6 +26,7 @@ class Provider(object):
         self.datatype = 'data'
         self.url = None
         self.data = None
+        self.proxies = None
 
     def _prepare_url(self, **kwargs):
         ...
@@ -35,12 +36,12 @@ class Provider(object):
 
     def _send_message(self):
         if self.method.upper() == 'GET':
-            response = self.request('get', self.url, params=self.data)
+            response = self.request('get', self.url, self.proxies, params=self.data)
         elif self.method.upper() == 'POST':
             if self.datatype.lower() == 'json':
-                response = self.request('post', self.url, json=self.data)
+                response = self.request('post', self.url, self.proxies, json=self.data)
             else:
-                response = self.request('post', self.url, data=self.data)
+                response = self.request('post', self.url, self.proxies, data=self.data)
         else:
             raise OnePushException('Request method {} not supported.'.format(self.method))
 
@@ -60,8 +61,10 @@ class Provider(object):
         return message
 
     @staticmethod
-    def request(method, url, **kwargs):
+    def request(method, url, proxies, **kwargs):
         session = requests.Session()
+        if proxies:
+            session.proxies.update(proxies)
         response = None
         try:
             response = session.request(method, url, **kwargs)
@@ -76,6 +79,7 @@ class Provider(object):
             return response
 
     def notify(self, **kwargs):
+        self.proxies = kwargs.pop('proxies', '')
         self._prepare_url(**kwargs)
         self._prepare_data(**kwargs)
         return self._send_message()

--- a/onepush/core.py
+++ b/onepush/core.py
@@ -79,7 +79,7 @@ class Provider(object):
             return response
 
     def notify(self, **kwargs):
-        self.proxies = kwargs.pop('proxies', '')
+        self.proxies = kwargs.pop('proxies', None)
         self._prepare_url(**kwargs)
         self._prepare_data(**kwargs)
         return self._send_message()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
+requests[socks]
 pycryptodome


### PR DESCRIPTION
pytest测试用例：

```python
import unittest
import onepush  

class TestCoreFunctionality(unittest.TestCase):
    def test_notify_function(self):
        proxies = [
            {'http': 'http://127.0.0.1:7890', 'https': 'http://127.0.0.1:7890'},
            {'http': 'socks5h://127.0.0.1:7890', 'https': 'socks5h://127.0.0.1:7890'},
        ]
        for proxy in proxies:
            response = onepush.notify(
                "telegram",
                title="Test Title",
                content="Test Content",
                token="123456:ABC-DEF",
                userid="123456",
                proxies=proxy
            )
            self.assertIsNotNone(response)

if __name__ == '__main__':
    unittest.main()
```
requests[socks]通过集成PySocks支持socks代理，但由于[默认采用远程解析](https://github.com/Anorov/PySocks/blob/c2fa43cbe1091e799e248e8e4433978916791a8b/socks.py#L310-L311)，所以本地socks5代理需写作`socks5h`

https://requests.readthedocs.io/en/latest/user/advanced/#proxies