### PR TITLE
fix: 修复proxies无默认值报错 feature: 为企业微信app推送添加设置自定义url功能，以绕过IP白名单限制

### DIFF
--- a/onepush/__version__.py
+++ b/onepush/__version__.py
@@ -4,4 +4,4 @@
 @Blog      : https://www.yindan.me
 """
 
-__version__ = '1.5.0'
+__version__ = '1.7.0'

--- a/onepush/core.py
+++ b/onepush/core.py
@@ -61,7 +61,7 @@ class Provider(object):
         return message
 
     @staticmethod
-    def request(method, url, proxies, **kwargs):
+    def request(method, url, proxies = None, **kwargs):
         session = requests.Session()
         if proxies:
             session.proxies.update(proxies)

--- a/onepush/providers/wechatworkapp.py
+++ b/onepush/providers/wechatworkapp.py
@@ -14,16 +14,34 @@ class WechatWorkApp(Provider):
 
     _params = {
         'required': ['corpid', 'corpsecret', 'agentid'],
-        'optional': ['title', 'content', 'touser', 'markdown', 'media_id']
+        'optional': ['title', 'content', 'touser', 'markdown', 'media_id', 'custom_url']
     }
 
     def _prepare_url(self, corpid: str, corpsecret: str, **kwargs):
-        url = 'https://qyapi.weixin.qq.com/cgi-bin/gettoken'
+        custom = kwargs.get('custom_url')
+        if custom:
+            # normalize: if no scheme, assume https
+            if not custom.startswith('http://') and not custom.startswith('https://'):
+                custom = 'https://' + custom
+            # ensure no trailing slash
+            custom = custom.rstrip('/')
+            url = f"{custom}/cgi-bin/gettoken"
+        else:
+            url = 'https://qyapi.weixin.qq.com/cgi-bin/gettoken'
         data = {'corpid': corpid, 'corpsecret': corpsecret}
         response = self.request('get', url, params=data).json()
         access_token = response.get('access_token')
 
-        self.url = self.base_url.format(access_token)
+        # build send message URL; if custom_url present, replace host in base_url
+        custom_send = kwargs.get('custom_url')
+        if custom_send:
+            send_host = custom_send
+            if not send_host.startswith('http://') and not send_host.startswith('https://'):
+                send_host = 'https://' + send_host
+            send_host = send_host.rstrip('/')
+            self.url = f"{send_host}/cgi-bin/message/send?access_token={access_token}"
+        else:
+            self.url = self.base_url.format(access_token)
         return self.url
 
     def _prepare_data(self,


### PR DESCRIPTION
fix: 修复proxies未设置默认值导致的无代理情况推送错误

feature: 为企业微信app推送添加设置自定义url功能，以绕过IP白名单限制
caddy反代配置文件如下：
```
your_url {
        reverse_proxy https://qyapi.weixin.qq.com {
                header_up Host {http.reverse_proxy.upstream.hostport}
        }
}
```

顺便更新了版本号到1.7，方便作者更新pypi