### PR TITLE
feature: update bark parameters and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ from onepush import get_notifier
 n = get_notifier('bark')
 print(n.params)
 
-response = n.notify(key='YOUR_BARK_KEY', title='OnePush', content='Hello World!')
+response = n.notify(device_key='YOUR_BARK_KEY', title='OnePush', content='Hello World!')
 print(response.text)
 
-# {'required': ['key'], 'optional': ['title', 'content', 'sound', 'isarchive', 'icon', 'group', 'url', 'copy', 'autocopy']}
+# {'required': ['device_key'], 'optional': ['title', 'subtitle', 'body', 'markdown', 'device_key', 'device_keys', 'level', 'volume', 'badge', 'call', 'autoCopy', 'copy', 'sound', 'icon', 'image', 'group', 'ciphertext', 'isArchive', 'url', 'action', 'id', 'delete', 'cipherkey', 'ciphermethod', 'base_url', 'content', 'key']}
 # {"code":200,"message":"success","timestamp":1633528319}
 ```
 
@@ -42,6 +42,12 @@ Or:
 ```python
 from onepush import notify
 
+notify('bark', device_key='YOUR_BARK_KEY', title='OnePush', content='Hello World!')
+```
+
+You can also use the alias `key` for `device_key`:
+
+```python
 notify('bark', key='YOUR_BARK_KEY', title='OnePush', content='Hello World!')
 ```
 
@@ -57,7 +63,7 @@ proxies = {
 }
 
 notify('bark', 
-       key='YOUR_BARK_KEY', 
+       device_key='YOUR_BARK_KEY', 
        title='OnePush', 
        content='Hello World!',
        proxies=proxies)

--- a/onepush/__version__.py
+++ b/onepush/__version__.py
@@ -4,4 +4,4 @@
 @Blog      : https://www.yindan.me
 """
 
-__version__ = '1.8.1'
+__version__ = '1.9.0'

--- a/onepush/providers/bark.py
+++ b/onepush/providers/bark.py
@@ -16,48 +16,115 @@ from ..core import Provider
 
 class Bark(Provider):
     name = 'bark'
-    base_url = 'https://api.day.app/{}'
+    base_url = 'https://api.day.app/push'
     site_url = 'https://apps.apple.com/us/app/bark-customed-notifications/id1403753865'
 
     _params = {
-        'required': ['key'],
+        'required': ['device_key'],
         'optional': [
-            'title', 'content', 'sound', 'isarchive', 'icon', 'group', 'url', 'copy',
-            'autocopy', 'cipherkey', 'ciphermethod',
+            'title',
+            'subtitle',
+            'body',
+            'markdown',
+            'device_keys',
+            'level',
+            'volume',
+            'badge',
+            'call',
+            'autoCopy',
+            'copy',
+            'sound',
+            'icon',
+            'image',
+            'group',
+            'ciphertext',
+            'isArchive',
+            'url',
+            'action',
+            'id',
+            'delete',
+            'cipherkey',
+            'ciphermethod',
+            # Custom parameters
+            'base_url',
+            # Aliases
+            'key', # <-> device_key
+            'content', # <-> body
+            'autocopy', # <-> autoCopy
+            'isarchive', # <-> isArchive
         ]
     }
 
-    def _prepare_url(self, key: str, **kwargs):
-        self.url = key
-        if 'https' not in key and 'http' not in key:
-            self.url = self.base_url.format(key)
+    def _prepare_url(self, base_url: str = None, **kwargs):
+        self.method = 'post'
+
+        if base_url:
+            self.base_url = base_url
+
+        self.url = self.base_url
+        if not self.url.endswith('/push'):
+            self.url += '/push'
+
         return self.url
 
     def _prepare_data(self,
-                      title: str = None,
+                      key: str = None,
                       content: str = None,
-                      sound: str = 'healthnotification',
-                      isarchive: int = None,
-                      icon: str = None,
-                      group: str = None,
-                      url: str = None,
-                      copy: str = None,
-                      autocopy: int = None,
                       cipherkey: str = None,
                       ciphermethod: str = None,
                       **kwargs):
-        self.data = {
-            'title': title,
+        self.datatype = 'json'
+
+        params = {
+            'title': None,
+            'subtitle': None,
             'body': content,
-            'sound': sound,
-            'isArchive': 1 if isarchive else isarchive,
-            'icon': icon,
-            'group': group,
-            'url': url,
-            'copy': copy,
-            'autoCopy': 1 if autocopy else autocopy
+            'markdown': None,
+            'device_key': key,
+            'device_keys': None,
+            'level': None,
+            'volume': None,
+            'badge': None,
+            'call': None,
+            'autoCopy': None,
+            'copy': None,
+            'sound': None,
+            'icon': None,
+            'image': None,
+            'group': None,
+            'ciphertext': None,
+            'isArchive': None,
+            'url': None,
+            'action': None,
+            'id': None,
+            'delete': None,
         }
-        self._encrypt_data(cipherkey, ciphermethod)
+
+        for field in params:
+            if field in kwargs:
+                params[field] = kwargs.get(field)
+
+        if params['autoCopy'] is None and 'autocopy' in kwargs:
+            params['autoCopy'] = kwargs.get('autocopy')
+        if params['isArchive'] is None and 'isarchive' in kwargs:
+            params['isArchive'] = kwargs.get('isarchive')
+
+        # Remove None values to avoid Bark server JSON parsing errors
+        self.data = {k: v for k, v in params.items() if v is not None}
+
+        if params['ciphertext']:
+            self.data = {
+                'ciphertext': params['ciphertext'],
+                'device_key': params['device_key'],
+                'device_keys': params['device_keys'],
+            }
+            iv = kwargs.get('iv')
+            if iv:
+                self.data['iv'] = iv
+            self.data = {k: v for k, v in self.data.items() if v is not None}
+        else:
+            self._encrypt_data(cipherkey, ciphermethod)
+
         return self.data
 
     def _encrypt_data(self, key: str, method: str):
@@ -78,7 +145,7 @@ class Bark(Provider):
             'ciphertext': ciphertext,
             'iv': iv.decode('ascii'),
         }
-    
+
     def _encrypt_by_ecb(self, key: str):
         body = json.dumps(self.data)
         cipher = AES.new(key.encode(), AES.MODE_ECB)


### PR DESCRIPTION
This pull request introduces significant updates to the Bark provider integration in the `onepush` library, improving parameter handling, aligning with the latest Bark API, and clarifying usage in the documentation. The changes modernize the way notification parameters are managed, add support for new Bark features, and ensure backward compatibility with aliases.

**Bark Provider Overhaul and API Alignment:**

* Updated the Bark provider (`bark.py`) to use the new Bark API endpoint (`/push`), expanded the list of supported parameters (including new features like `subtitle`, `markdown`, `level`, `volume`, etc.), and refactored the parameter mapping to support both new and legacy aliases (e.g., `device_key`/`key`, `body`/`content`). The provider now sends data as JSON and better handles optional parameters and encryption workflows.

* Changed the required parameter from `key` to `device_key` in both the Bark provider and the documentation, reflecting the Bark API's current requirements. [[1]](diffhunk://#diff-4889954e4ceb25d42ec0e2c2987a91a302bd184a11c4626da1cf8e9da078c16aL19-R127) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R36)

**Documentation and Usage Examples:**

* Updated all `README.md` usage examples to use `device_key` instead of `key`, clarified the list of supported parameters, and demonstrated that `key` remains an alias for backward compatibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R66)

**Versioning:**

* Bumped the package version from `1.8.1` to `1.9.0` to reflect these breaking and feature changes.